### PR TITLE
Antes da camada de apresentação dados

### DIFF
--- a/src/nestjs/jest.config.ts
+++ b/src/nestjs/jest.config.ts
@@ -5,7 +5,7 @@ export default {
   },
   moduleFileExtensions: ['js', 'json', 'ts'],
   rootDir: 'src',
-  testRegex: '.*\\.spec\\.ts$',
+  testRegex: ".*\\..*spec\\.ts$",
   transform: {
     '^.+\\.(t|j)s$': '@swc/jest',
   },

--- a/src/nestjs/src/categories/__tests__/integration/categories.controller.int-spec.ts
+++ b/src/nestjs/src/categories/__tests__/integration/categories.controller.int-spec.ts
@@ -3,6 +3,13 @@ import { CategoriesController } from '../../categories.controller';
 import { CategoriesModule } from '../../categories.module';
 import { ConfigModule } from '../../../config/config.module';
 import { DatabaseModule } from '../../../database/database.module';
+import {
+  CreateCategoryUseCase,
+  UpdateCategoryUseCase,
+  ListCategoriesUseCase,
+  GetCategoryUseCase,
+  DeleteCategoryUseCase,
+} from '@fc/micro-videos/category/application';
 
 describe('CategoriesController Integration Tests', () => {
   let controller: CategoriesController;
@@ -15,7 +22,20 @@ describe('CategoriesController Integration Tests', () => {
     controller = module.get(CategoriesController);
   });
 
-  it('xpto', () => {
-    console.log(controller);
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+    expect(controller['createUseCase']).toBeInstanceOf(
+      CreateCategoryUseCase.UseCase,
+    );
+    expect(controller['updateUseCase']).toBeInstanceOf(
+      UpdateCategoryUseCase.UseCase,
+    );
+    expect(controller['listUseCase']).toBeInstanceOf(
+      ListCategoriesUseCase.UseCase,
+    );
+    expect(controller['getUseCase']).toBeInstanceOf(GetCategoryUseCase.UseCase);
+    expect(controller['deleteUseCase']).toBeInstanceOf(
+      DeleteCategoryUseCase.UseCase,
+    );
   });
 });

--- a/src/nestjs/src/categories/__tests__/integration/categories.controller.int-spec.ts
+++ b/src/nestjs/src/categories/__tests__/integration/categories.controller.int-spec.ts
@@ -65,4 +65,75 @@ describe('CategoriesController Integration Tests', () => {
     expect(output.name).toBeTruthy();
     expect(output.created_at).toStrictEqual(entity.created_at);
   });
+
+  describe('should create a category with testEach', () => {
+    const arrange = [
+      {
+        request: {
+          name: 'Movie',
+        },
+        expectedOutput: {
+          name: 'Movie',
+          description: null,
+          is_active: true,
+        },
+      },
+      {
+        request: {
+          name: 'Movie',
+          description: null,
+        },
+        expectedOutput: {
+          name: 'Movie',
+          description: null,
+          is_active: true,
+        },
+      },
+      {
+        request: {
+          name: 'Movie',
+          is_active: true,
+        },
+        expectedOutput: {
+          name: 'Movie',
+          description: null,
+          is_active: true,
+        },
+      },
+      {
+        request: {
+          name: 'Movie',
+          description: 'some text',
+          is_active: false,
+        },
+        expectedOutput: {
+          name: 'Movie',
+          description: 'some text',
+          is_active: false,
+        },
+      },
+    ];
+
+    test.each(arrange)(
+      'with request $request',
+      async ({ request, expectedOutput }) => {
+        const output = await controller.create(request);
+        const entity = await repository.findById(output.id);
+
+        expect(entity).toMatchObject({
+          id: output.id,
+          name: expectedOutput.name,
+          description: expectedOutput.description,
+          is_active: expectedOutput.is_active,
+          created_at: output.created_at,
+        });
+
+        expect(output.id).toBe(entity.id);
+        expect(output.name).toBe(expectedOutput.name);
+        expect(output.description).toBe(expectedOutput.description);
+        expect(output.is_active).toBe(expectedOutput.is_active);
+        expect(output.created_at).toStrictEqual(entity.created_at);
+      },
+    );
+  });
 });

--- a/src/nestjs/src/categories/__tests__/integration/categories.controller.int-spec.ts
+++ b/src/nestjs/src/categories/__tests__/integration/categories.controller.int-spec.ts
@@ -10,9 +10,12 @@ import {
   GetCategoryUseCase,
   DeleteCategoryUseCase,
 } from '@fc/micro-videos/category/application';
+import { CategoryRepository } from '@fc/micro-videos/category/domain';
+import { CATEGORY_PROVIDERS } from '../../category.providers';
 
 describe('CategoriesController Integration Tests', () => {
   let controller: CategoriesController;
+  let repository: CategoryRepository.Repository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -20,6 +23,9 @@ describe('CategoriesController Integration Tests', () => {
     }).compile();
 
     controller = module.get(CategoriesController);
+    repository = module.get(
+      CATEGORY_PROVIDERS.REPOSITORIES.CATEGORY_REPOSITORY.provide,
+    );
   });
 
   it('should be defined', () => {
@@ -37,5 +43,26 @@ describe('CategoriesController Integration Tests', () => {
     expect(controller['deleteUseCase']).toBeInstanceOf(
       DeleteCategoryUseCase.UseCase,
     );
+  });
+
+  it('should create a category', async () => {
+    const output = await controller.create({
+      name: 'Movie',
+    });
+    const entity = await repository.findById(output.id);
+
+    expect(entity).toMatchObject({
+      id: output.id,
+      name: 'Movie',
+      description: null,
+      is_active: true,
+      created_at: output.created_at,
+    });
+
+    expect(output.id).toBe(entity.id);
+    expect(output.name).toBe('Movie');
+    expect(output.description).toBeNull();
+    expect(output.name).toBeTruthy();
+    expect(output.created_at).toStrictEqual(entity.created_at);
   });
 });

--- a/src/nestjs/src/categories/__tests__/integration/categories.controller.int-spec.ts
+++ b/src/nestjs/src/categories/__tests__/integration/categories.controller.int-spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesController } from '../../categories.controller';
+import { CategoriesModule } from '../../categories.module';
+import { ConfigModule } from '../../../config/config.module';
+import { DatabaseModule } from '../../../database/database.module';
+
+describe('CategoriesController Integration Tests', () => {
+  let controller: CategoriesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot(), DatabaseModule, CategoriesModule],
+    }).compile();
+
+    controller = module.get(CategoriesController);
+  });
+
+  it('xpto', () => {
+    console.log(controller);
+  });
+});

--- a/src/nestjs/src/categories/__tests__/unit/categories.controller.spec.ts
+++ b/src/nestjs/src/categories/__tests__/unit/categories.controller.spec.ts
@@ -5,9 +5,9 @@ import {
   ListCategoriesUseCase,
 } from '@fc/micro-videos/category/application';
 import { SortDirection } from '@fc/micro-videos/dist/@seedwork/domain/repository/repository-contracts';
-import { CategoriesController } from './categories.controller';
-import { CreateCategoryDto } from './dto/create-category.dto';
-import { UpdateCategoryDto } from './dto/update-category.dto';
+import { CategoriesController } from '../../categories.controller';
+import { CreateCategoryDto } from '../../dto/create-category.dto';
+import { UpdateCategoryDto } from '../../dto/update-category.dto';
 //import { Test, TestingModule } from '@nestjs/testing';
 //import { CategoriesService } from './categories.service';
 

--- a/src/nestjs/src/categories/__tests__/unit/categories.service.spec.ts
+++ b/src/nestjs/src/categories/__tests__/unit/categories.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CategoriesService } from './categories.service';
+import { CategoriesService } from '../../categories.service';
 
 describe('CategoriesService', () => {
   let service: CategoriesService;

--- a/src/nestjs/src/categories/categories.controller.ts
+++ b/src/nestjs/src/categories/categories.controller.ts
@@ -71,3 +71,7 @@ export class CategoriesController {
     return this.deleteUseCase.execute({ id });
   }
 }
+
+// Controller tests
+//  integration: sqlite in memory
+//  end-to-end: more expensive, bureaucratic and longstanding

--- a/src/nestjs/src/categories/categories.module.ts
+++ b/src/nestjs/src/categories/categories.module.ts
@@ -15,3 +15,9 @@ import { CategorySequelize } from '@fc/micro-videos/category/infra';
   ],
 })
 export class CategoriesModule {}
+
+// checks at categoriesmodule
+// load module
+// check imports
+// check controllers
+// check providers


### PR DESCRIPTION
A partir daqui terá uma camada de apresentação que pode ser considerada supérflua para este projeto. Está sendo incluída por motivos didáticos e seria recomendada em projetos que exijam uma coversão entre a saída do usecase e a apresentação dos dados persistidos. (creio eu)